### PR TITLE
Refactor tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,14 +5,11 @@ const mongoose = require('mongoose');
 const app = express();
 
 if (process.env.ENV === 'Test') {
-  console.log('This is a test');
-  mongoose.connect('mongodb://localhost/weather-data-test');
+  mongoose.connect('mongodb://localhost/weather-data-test', { useNewUrlParser: true });
 } else if (process.env.MONGODB_URI) {
-  console.log('This is Heroku');
-  mongoose.connect(process.env.MONGODB_URI);
+  mongoose.connect(process.env.MONGODB_URI, { useNewUrlParser: true });
 } else {
-  console.log('This is the development database');
-  mongoose.connect('mongodb://localhost/weather-data-dev');
+  mongoose.connect('mongodb://localhost/weather-data-dev', { useNewUrlParser: true });
 }
 
 const WeatherRecord = require('./models/weatherDataModel');
@@ -44,7 +41,9 @@ app.post('/api/data', (req, res) => {
 
 
 app.server = app.listen(port, () => {
-  console.log(`Running on port ${port}`);
+  if (process.env.ENV !== 'Test' && !process.env.MONGODB_URI) {
+    console.log(`Running on port ${port}`);
+  }
 });
 
 module.exports = app;

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "start": "nodemon app.js",
-    "test": "mocha tests/**/*Tests.js",
-    "coverage": "nyc npm run test"
+    "test": "nyc mocha tests/**/*Tests.js"
   },
   "repository": {
     "type": "git",

--- a/tests/routeTests.js
+++ b/tests/routeTests.js
@@ -26,109 +26,102 @@ describe('Testing "/" Route', () => {
   });
 });
 
-describe('Testing the api route', () => {
-  it('returns a confirmation message', (done) => {
-    agent.post('/api/data')
-      .send({
-        temperature: 20,
-        humidity: 50,
-        pressure: 1000,
-        date: 1560643200000, // = 2019/5/16
-      })
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .end((err, res) => {
-        // if (err) return done(err);
-        res.status.should.equal(200);
-        res.body.message.should.equal('Record saved');
-        done();
-      });
-  });
+describe('Testing the api POST route', function() {
+  describe('If the data in the request is valid', function() {
+    it('the data is saved in the database', function(done) {
+      agent.post('/api/data')
+        .send({
+          temperature: 32,
+          humidity: 67,
+          pressure: 100,
+          date: 1560643200000, // = 2019/5/16
+        })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          const id = res.body.record._id;
 
-  it("returns a helpful message if it couldn't save", (done) => {
-    agent.post('/api/data')
-      .send({
-        temperature: 'a string',
-      })
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .end((err, res) => {
-        // if (err) return done(err);
-        res.status.should.equal(200);
-        res.body.message.should.equal('Record was not saved');
-        done();
-      });
-  });
+          WeatherRecord.findById(id, (err2, weatherRecord) => {
+            weatherRecord.temperature.should.equal(32);
+            done();
+          });
+        });
+    });
 
-  it("response include the Mongo error if it couldn't save", (done) => {
-    agent.post('/api/data')
-      .send({
-        temperature: 'a string',
-        humidity: 'asdasd',
-      })
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .end((err, res) => {
-        // if (err) return done(err);
-        res.body.mongoResponse.errors.temperature.message
-          .should.equal('Cast to Number failed for value "a string" at path "temperature"');
-        done();
-      });
-  });
-
-  it('saves the data in the database for a legit input', (done) => {
-    agent.post('/api/data')
-      .send({
-        temperature: 32,
-        humidity: 67,
-        pressure: 100,
-        date: 1560643200000, // = 2019/5/16
-      })
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .end((err, res) => {
-        // eslint-disable-next-line no-underscore-dangle
-        const id = res.body.record._id;
-
-        WeatherRecord.findById(id, (err2, weatherRecord) => {
-          weatherRecord.temperature.should.equal(32);
+    it('the response contains a confirmation message', function(done) {
+      agent.post('/api/data')
+        .send({
+          temperature: 20,
+          humidity: 50,
+          pressure: 1000,
+          date: 1560643200000, // = 2019/5/16
+        })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          // if (err) return done(err);
+          res.status.should.equal(200);
+          res.body.message.should.equal('Record saved');
           done();
         });
-      });
+    });
   });
 
-  it("returns an error message if it doesn't validate", (done) => {
-    agent.post('/api/data')
-      .send({ })
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .end((err, res) => {
-        res.body.message.should.equal('Record was not saved');
-        done();
-      });
-  });
+  describe('If the data in the request is not valid', function() {
+    it("it isn't saved in the database", function(done) {
+      agent.post('/api/data')
+        .send({
+          humidity: 67,
+          pressure: 100,
+          date: 1, // = 2019/5/16
+        })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end(() => {
+          WeatherRecord.find({ date: 1 }, (err, weatherRecord) => {
+            weatherRecord.should.be.empty();
+            done();
+          });
+        });
+    });
 
-  it("doesn't save the data in the database if it doesn't validate", (done) => {
-    agent.post('/api/data')
-      .send({
-        humidity: 67,
-        pressure: 100,
-        date: 1, // = 2019/5/16
-      })
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .end(() => {
-        WeatherRecord.find({ date: 1 }, (err, weatherRecord) => {
-          weatherRecord.should.be.empty();
+    it("the response includes an error message", function(done) {
+      agent.post('/api/data')
+        .send({
+          humidity: 67,
+          pressure: 100,
+          date: 1, // = 2019/5/16
+        })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          // if (err) return done(err);
+          res.status.should.equal(200);
+          res.body.message.should.equal('Record was not saved');
           done();
         });
-      });
+    });
+
+    it("the response includes the Mongo error", function(done) {
+      agent.post('/api/data')
+        .send({
+          temperature: 'a string',
+          humidity: 'asdasd',
+        })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          // if (err) return done(err);
+          res.body.mongoResponse.errors.temperature.message
+            .should.equal('Cast to Number failed for value "a string" at path "temperature"');
+          done();
+        });
+    });
   });
 
   afterEach((done) => {


### PR DESCRIPTION
- Rewrite tests to use functions instead of lambdas, as suggested in the Mocha docs: <https://mochajs.org/#arrow-functions>
- Organise tests using `describe` blocks
- Add `{ useNewUrlParser: true }` to Mongo connection to stop deprecation warning appearing in test output
- Include test coverage when running `npm test`