### PR TITLE
Api filter by date

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,9 +30,11 @@ app.all('/api/data', function(req, res, next) {
 });
 
 app.get('/api/data', (req, res) => {
-  WeatherRecord.find((err, weatherData) => {
-    res.send(weatherData);
-  });
+  const query = req.query;
+  WeatherRecord.find().where('date').gt(query.initial_datetime)
+    .exec((err, weatherData) => {
+      res.send(weatherData);
+    });
 });
 
 app.post('/api/data', (req, res) => {

--- a/app.js
+++ b/app.js
@@ -31,11 +31,15 @@ app.all('/api/data', (req, res, next) => {
 
 app.get('/api/data', (req, res) => {
   const { query } = req;
+  query.final_datetime = query.final_datetime
+                         || new Date(new Date().getTime());
   query.initial_datetime = query.initial_datetime
-                           || new Date(new Date().getTime() - 86400000); // 24 hours ago
+                           || new Date(new Date(query.final_datetime) - 86400000); // 24 hours ago
 
   WeatherRecord.find()
     .where('date').gt(query.initial_datetime)
+    .where('date')
+    .lt(query.final_datetime)
     .exec((err, weatherData) => {
       res.send(weatherData);
     });

--- a/app.js
+++ b/app.js
@@ -23,15 +23,19 @@ app.get('/', (req, res) => {
   res.send('Hello from [placeholder]');
 });
 
-app.all('/api/data', function(req, res, next) {
-  res.header("Access-Control-Allow-Origin", "*");
-  res.header("Access-Control-Allow-Headers", "X-Requested-With");
+app.all('/api/data', (req, res, next) => {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Headers', 'X-Requested-With');
   next();
 });
 
 app.get('/api/data', (req, res) => {
-  const query = req.query;
-  WeatherRecord.find().where('date').gt(query.initial_datetime)
+  const { query } = req;
+  query.initial_datetime = query.initial_datetime
+                           || new Date(new Date().getTime() - 86400000); // 24 hours ago
+
+  WeatherRecord.find()
+    .where('date').gt(query.initial_datetime)
     .exec((err, weatherData) => {
       res.send(weatherData);
     });


### PR DESCRIPTION
`initial_datetime` and `final_datetime` can be provided. if not
provided, `final_datetime` defaults to current time. if not provided,
`initial_datetime` defaults to 24 hours before `final_datetime`.